### PR TITLE
Integrate helper methods to clean up index videos

### DIFF
--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -20,7 +20,7 @@ module VideosHelper
 
   def link_to_song_id(song_attributes)
     link_to song_attributes,
-            root_path(song_id: @video.song_id),
+            root_path(song_id: "video.song_id"),
             { 'data-turbo-frame': "_top" }
   end
 
@@ -46,5 +46,17 @@ module VideosHelper
 
   def formatted_metadata(video)
     "#{formatted_upload_date(video.upload_date)} • #{video.view_count} views • #{video.like_count} likes"
+  end
+
+  def hd_duration_data(video)
+    if video.hd?
+      "HD #{Time.at(video.duration).utc.strftime('%M:%S')}"
+    else
+      Time.at(video.duration).utc.strftime("%M:%S")
+    end
+  end
+
+  def channel_title(video)
+    truncate(video.channel.title, length: 45, omission: "")
   end
 end

--- a/app/views/videos/index/_videos.html.erb
+++ b/app/views/videos/index/_videos.html.erb
@@ -1,49 +1,38 @@
 <% @videos_paginated.each do |video| %>
     <article class="video-container">
       <%= link_to watch_path(v: video.youtube_id), {active: :exact} do %>
-        <div class="thumbnail" data-duration= "<%= video.hd? ? "HD #{Time.at(video.duration).utc.strftime("%M:%S")}" : Time.at(video.duration).utc.strftime("%M:%S") %>" >
+        <div class="thumbnail" data-duration= "<%= hd_duration_data(video) %>" >
           <%= image_tag("https://img.youtube.com/vi/#{video.youtube_id}/hqdefault.jpg", class: "thumbnail-image") %>
         </div>
       <% end %>
       <div class="video-bottom-section">
         <div class="video-details">
           <div class="video-title">
-            <% if video.leader.present? && video.follower.present? && video.song.present? %>
-              <%= link_to "#{video.leader.name} & #{video.follower.name}", watch_path(v: video.youtube_id), class: "video-details-section-dancers" %>
-            <% elsif video.leader.present? && video.follower.present? && video.spotify_track_name.present? %>
-              <%= link_to "#{video.leader.name} & #{video.follower.name}", watch_path(v: video.youtube_id), class: "video-details-section-dancers" %>
-            <% elsif video.leader.present? && video.follower.present? && video.youtube_song.present? %>
-              <%= link_to "#{video.leader.name} & #{video.follower.name}", watch_path(v: video.youtube_id), class: "video-details-section-dancers" %>
-            <% else %>
-              <%= link_to truncate(video.title, length: 85), watch_path(v: video.youtube_id), class: "video-title" %>
-            <% end %>
+          <%= link_to_primary_title(video.display.dancer_names,
+                                    video.title,
+                                    video.display.el_recodo_attributes,
+                                    video.youtube_id) %>
           </div>
           <div class="video-song">
-            <% if video.song.present? %>
-              <%= link_to root_path(song_id: video.song_id) do %>
-                <%= video.song.title.to_s.titleize + ' - ' + video.song.artist.to_s.titleize + ' - ' + video.song.genre.to_s.titleize %>
-                <br>
-
-              <% end %>
-            <% end %>
-            <% if video.song.nil? && video.spotify_track_name.present? %>
-              <%= link_to video.try(:spotify_track_name).to_s.titleize + ' - ' + video.try(:spotify_artist_name).to_s.titleize, root_path(query: video.try(:spotify_track_name).to_s.titleize + ' - ' + video.try(:spotify_artist_name).to_s.titleize) %>
-            <% end %>
-            <% if video.song.nil? && video.spotify_track_name.nil? && video.youtube_artist.present? %>
-              <%= link_to "#{video.youtube_song.to_s.titleize} - #{video.youtube_artist.to_s.titleize}", root_path(query: "#{video.youtube_song.to_s.titleize} - #{video.youtube_artist.to_s.titleize}")  %>
-            <% end %>
+          <% if video.display.any_song_attributes.present? %>
+            <%= link_to_song(video.display.el_recodo_attributes,
+                              video.display.external_song_attributes) %>
+          <% end %>
           </div>
           <div class="video-event">
-              <%= link_to video.event.title.titleize, root_path(event_id: video.event.id) if video.event.present? %>
+              <%= link_to video.event.title.titleize,
+                          root_path(event_id: video.event.id) if video.event.present? %>
           </div>
           <div class="video-channel">
-            <%= link_to image_tag(video.channel.thumbnail_url, class: 'channel-icon'), root_path(channel: video.channel.title) if video.channel.thumbnail_url.present? %>
-            <%= link_to truncate(video.channel.title, length: 45, omission: ''), root_path(channel: video.channel.title), class: "channel-title" if video.channel.title.present? %>
+            <%= link_to image_tag(video.channel.thumbnail_url,
+                          class: 'channel-icon'),
+                          root_path(channel: video.channel.title) if video.channel.thumbnail_url.present? %>
+            <%= link_to channel_title(video),
+                          root_path(channel: video.channel.title),
+                          class: "channel-title" if video.channel.title.present? %>
           </div>
           <div class="video-metadata">
-            <% if video.upload_date.present? && video.view_count.present? %>
-              <%= "#{number_to_human(video.view_count, :format => '%n%u', :precision => 2, :units => { :thousand => 'K', :million => 'M', :billion => 'B' })} views • #{video.upload_date.strftime('%b %Y')}" %>
-            <% end %>
+              <%= formatted_metadata(video) %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This was incorporated in the past, but somehow fell out. The videos view has some complicated logic to figure out how to format the titles for each video dependent on which information is present. This has been moved to video helpers but they weren't being used.

I have also added video helpers to further clean up the view.